### PR TITLE
Added panel command and fixed UDP command reformat

### DIFF
--- a/P3DInstruments/P3DControl/CommandInterpreter.cpp
+++ b/P3DInstruments/P3DControl/CommandInterpreter.cpp
@@ -12,6 +12,7 @@
 #include "WeatherMessageHandler.h"
 #include "IgcMessageHandler.h"
 #include "LogMessageHandler.h"
+#include "PanelMessageHandler.h"
 #include "QuitHandler.h"
 #include "JSONWriter.h"
 #include "APIParameters.h"
@@ -31,6 +32,7 @@ CommandInterpreter::CommandInterpreter(Prepar3D* pSim)
 	add(new WeatherMessageHandler(pSim));
 	add(new IgcMessageHandler(pSim));
 	add(new LogMessageHandler(pSim));
+	add(new PanelMessageHandler(pSim));
 }
 
 CommandInterpreter::~CommandInterpreter()

--- a/P3DInstruments/P3DControl/MessageThread.cpp
+++ b/P3DInstruments/P3DControl/MessageThread.cpp
@@ -45,12 +45,9 @@ unsigned MessageThread::run()
 		}
 
 		// Replace any pipe characters with slash to make early UDP messsages more webby
-		pos = cmd.find_first_of(cmd, '|');
-		while (pos != std::string::npos) {
-			cmd[pos] = '/';
-			pos = cmd.find_first_of('|', pos);
-		}
-
+		// allows pipe separator in UDP messages
+		replace(cmd, '|', '/');
+		
 		process(cmd, param);
 	}
 	return 0;
@@ -61,6 +58,17 @@ unsigned MessageThread::run()
 void MessageThread::stop()
 {
 	this->quit = true;
+}
+
+// Replace any "from" chars in target with "to" chars. Returns the passed target string.
+std::string& MessageThread::replace(std::string& target, char from, char to)
+{
+	size_t pos = target.find_first_of(from);
+	while (pos != std::string::npos) {
+		target[pos] = to;
+		pos = target.find_first_of(from, pos);
+	}
+	return target;
 }
 
 void MessageThread::process(const std::string & cmd, const std::string & params)

--- a/P3DInstruments/P3DControl/MessageThread.h
+++ b/P3DInstruments/P3DControl/MessageThread.h
@@ -11,6 +11,7 @@ public:
 	~MessageThread();
 	virtual unsigned run();
 	void stop();
+	std::string& replace(std::string& target, char from, char to);
 
 private:
 	unsigned short port;

--- a/P3DInstruments/P3DControl/P3DControl.vcxproj
+++ b/P3DInstruments/P3DControl/P3DControl.vcxproj
@@ -186,6 +186,7 @@
     <ClInclude Include="MessageThread.h" />
     <ClInclude Include="P3DEventCommand.h" />
     <ClInclude Include="P3DInstallationDirectory.h" />
+    <ClInclude Include="PanelMessageHandler.h" />
     <ClInclude Include="PositionMessageHandler.h" />
     <ClInclude Include="QuitHandler.h" />
     <ClInclude Include="RecordMessageHandler.h" />
@@ -240,6 +241,7 @@
     <ClCompile Include="MessageThread.cpp" />
     <ClCompile Include="P3DEventCommand.cpp" />
     <ClCompile Include="P3DInstallationDirectory.cpp" />
+    <ClCompile Include="PanelMessageHandler.cpp" />
     <ClCompile Include="PositionMessageHandler.cpp" />
     <ClCompile Include="QuitHandler.cpp" />
     <ClCompile Include="RecordMessageHandler.cpp" />

--- a/P3DInstruments/P3DControl/P3DControl.vcxproj.filters
+++ b/P3DInstruments/P3DControl/P3DControl.vcxproj.filters
@@ -171,6 +171,9 @@
     <ClInclude Include="InitPosition.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PanelMessageHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -324,6 +327,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="InitPosition.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PanelMessageHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/P3DInstruments/P3DControl/PanelMessageHandler.cpp
+++ b/P3DInstruments/P3DControl/PanelMessageHandler.cpp
@@ -1,0 +1,40 @@
+#include "stdafx.h"
+#include "APIParameters.h"
+#include "../P3DCommon/UDPClient.h"
+#include "PanelMessageHandler.h"
+
+
+PanelMessageHandler::PanelMessageHandler(Prepar3D* p3d)
+	: MessageHandler(p3d,"panel")
+{
+}
+
+PanelMessageHandler::~PanelMessageHandler()
+{
+}
+
+void PanelMessageHandler::run(const std::string& cmd, const APIParameters& params, std::string& output)
+{
+	if (cmd == "send") {
+		std::string host = params.getString("host");
+		int port = params.getInt("port", 55278);
+		std::string cmd = params.getString("cmd");
+
+		if (host.empty() || cmd.empty()) {
+			reportFailure("Must supply both host and cmd to send data to panel", 0, output);
+		}
+		send(host, port, cmd, output);
+	}
+	else {
+		reportFailure("Unknown panel command ", 0, output);
+	}
+
+}
+
+void PanelMessageHandler::send(const std::string& host, int port, const std::string& cmd, std::string& output)
+{
+	UDPClient udp(host.c_str(), port);
+	udp.send(cmd);
+	reportSuccess(output);
+}
+

--- a/P3DInstruments/P3DControl/PanelMessageHandler.h
+++ b/P3DInstruments/P3DControl/PanelMessageHandler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "MessageHandler.h"
+class PanelMessageHandler :
+	public MessageHandler
+{
+
+public:
+	PanelMessageHandler(Prepar3D* p3d);
+	virtual ~PanelMessageHandler();
+
+	virtual void run(const std::string& cmd, const APIParameters& params, std::string& output);
+	void send(const std::string& host, int port, const std::string& cmd, std::string& output);
+};
+


### PR DESCRIPTION
panel/send command allows sending arbitrary strings via UDP.   Also fixed reformatting in MessageThread to properly change | to / characters.