### PR TITLE
Removed remaining references to V4 

### DIFF
--- a/P3DInstruments/P3DCommon/Prepar3D.cpp
+++ b/P3DInstruments/P3DCommon/Prepar3D.cpp
@@ -66,7 +66,9 @@ Prepar3D::Prepar3D(const char* appName, bool verbose)
 	simObjects(this),
 	wxStations(this),
 	extSim(0),
-	userAc(this)
+	userAc(this),
+	majorVersion(4), // until proven otherwise
+	minorVersion(0)
 {
 
 	// Create lookup tables for event definitions
@@ -172,12 +174,14 @@ void Prepar3D::showVersionInformation(SIMCONNECT_RECV* pData)
 		<< " Build " << pOpen->dwApplicationBuildMajor << "." << pOpen->dwApplicationBuildMinor << std::endl;
 	std::cout << "Sim Connect version " << pOpen->dwSimConnectVersionMajor << "." << pOpen->dwSimConnectBuildMinor << std::endl;
 
+	majorVersion = pOpen->dwApplicationVersionMajor;
+	minorVersion = pOpen->dwApplicationVersionMinor;
+
 	// Set up the document folder to one that matches the p3d version.
 	std::stringstream ss;
 	ss << "Prepar3D v" << pOpen->dwApplicationVersionMajor << " Files";
 	documents = ss.str();
 	std::cout << "Set documents folder to " << documentsFolder() << std::endl;
-
 }
 
 void Prepar3D::handleSystemEvent(SIMCONNECT_RECV* pData)

--- a/P3DInstruments/P3DCommon/Prepar3D.h
+++ b/P3DInstruments/P3DCommon/Prepar3D.h
@@ -64,6 +64,8 @@ private:
 	WeatherStations wxStations;
 	ExternalSim* extSim;
 	SimObject userAc;
+	int majorVersion;
+	int minorVersion;
 	std::string documents = "Prepar3D v4 Files"; // fallback to v4
 
     static void CALLBACK DispatchCallback(SIMCONNECT_RECV *pData, DWORD cbData, void *pContext);
@@ -160,6 +162,8 @@ public:
     void Dispatch();
 	void DispatchLoop();
 
+	int getMajorVersion() const { return majorVersion; }
+	int getMinorVersion() const { return minorVersion; }
 
 	LONG nextRequestId();	// Threadsafe counter for allocating request IDs.
 	//LONG nextEventId();		// Threadsafe counter for allocating event IDs.

--- a/P3DInstruments/P3DControl/P3DInstallationDirectory.h
+++ b/P3DInstruments/P3DControl/P3DInstallationDirectory.h
@@ -2,11 +2,13 @@
 #include "Folder.h"
 #include <string>
 
+class Prepar3D;
 
 class P3DInstallationDirectory :
 	public Directory
 {
-	std::string getInstallationDirectory();
+	int version;
+	std::string getInstallationDirectory(Prepar3D* p3d);
 public:
-	P3DInstallationDirectory();
+	P3DInstallationDirectory(Prepar3D* p3d);
 }; 

--- a/P3DInstruments/P3DControl/RecordMessageHandler.cpp
+++ b/P3DInstruments/P3DControl/RecordMessageHandler.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <sstream>
 #include "..//P3DCommon/Prepar3D.h"
 #include "RecordMessageHandler.h"
 #include "APIParameters.h"
@@ -9,6 +10,13 @@
 RecordMessageHandler::RecordMessageHandler(Prepar3D* p3d)
 	: MessageHandler(p3d, "record")
 {
+}
+
+std::string RecordMessageHandler::getSubFolder(Prepar3D* pSim) {
+	std::stringstream ss;
+	ss << "Prepar3D v" << pSim->getMajorVersion() << " files";
+	std::string subFolder = ss.str();
+	return subFolder;
 }
 
 bool RecordMessageHandler::start(Simulator* pSim)
@@ -35,7 +43,7 @@ bool RecordMessageHandler::playback(Simulator* pSim, const std::string& name)
 {
 	//Expand name to full path.
 	DocumentDirectory docs;
-	Directory recordingFolder = docs.sub("Prepar3D v4 files");
+	Directory recordingFolder = docs.sub(getSubFolder(pSim));  //was  "Prepar3D v4 files"
 	File file = recordingFolder.file(name.c_str());
 
 	HRESULT hr = SimConnect_PlaybackRecording(
@@ -57,10 +65,10 @@ bool RecordMessageHandler::analyse(Simulator* pSim)
 
 }
 
-File::ListT& RecordMessageHandler::list(File::ListT& files)
+File::ListT& RecordMessageHandler::list(Simulator* pSim, File::ListT& files)
 {
 	DocumentDirectory docs;
-	Directory recordingFolder = docs.sub("Prepar3D v4 files");
+	Directory recordingFolder = docs.sub(getSubFolder(pSim)); // was "Prepar3D v4 files"
 
 	recordingFolder.files(files, "*.fsr");
 
@@ -119,7 +127,7 @@ void RecordMessageHandler::saveAnalysis(std::string& output) {
 void RecordMessageHandler::listRecordings(std::string& output) {
 	try {
 		DocumentDirectory docs;
-		Directory recordingFolder = docs.sub("Prepar3D v4 files");
+		Directory recordingFolder = docs.sub(getSubFolder(p3d)); // "Prepar3D v4 files"
 
 		File::ListT files;
 		recordingFolder.files(files, "*.fsr");

--- a/P3DInstruments/P3DControl/RecordMessageHandler.h
+++ b/P3DInstruments/P3DControl/RecordMessageHandler.h
@@ -8,6 +8,8 @@ class RecordMessageHandler :
 	public MessageHandler
 {
 
+	static std::string getSubFolder(Prepar3D* pSim);
+
 public:
 	RecordMessageHandler(Prepar3D* p3d);
 	virtual void run(const std::string& cmd, const APIParameters& params, std::string& output);
@@ -16,7 +18,7 @@ public:
 	static bool stop(Simulator* pSim, const std::string& title, const std::string& description);
 	static bool playback(Simulator* pSim, const std::string& name);
 	static bool analyse(Simulator* pSim);
-	static File::ListT& list(File::ListT& files);
+	static File::ListT& list(Simulator* pSim, File::ListT& files);
 
 private:
 	void startRecording(std::string& output);

--- a/P3DInstruments/P3DControl/RecordScripting.cpp
+++ b/P3DInstruments/P3DControl/RecordScripting.cpp
@@ -64,7 +64,7 @@ int RecordScripting::list(lua_State* L)
 	Simulator* pSim = *(Simulator**)lua_getextraspace(L);
 
 	File::ListT files;
-	RecordMessageHandler::list(files);
+	RecordMessageHandler::list(pSim,files);
 	lua_newtable(L);
 
 	int idx = 1;

--- a/P3DInstruments/P3DControl/TrafficMessageHandler.cpp
+++ b/P3DInstruments/P3DControl/TrafficMessageHandler.cpp
@@ -143,10 +143,10 @@ bool TrafficMessageHandler::launch(Simulator* pSim, const std::string& targetNam
 	return hr == S_OK;
 }
 
-std::list<std::string>& TrafficMessageHandler::listAircraft(std::list<std::string>& aircraft)
+std::list<std::string>& TrafficMessageHandler::listAircraft(Simulator* pSim, std::list<std::string>& aircraft)
 {
 
-	P3DInstallationDirectory p3dInstall;
+	P3DInstallationDirectory p3dInstall(pSim);
 	Directory airplanesFolder = p3dInstall.sub("SimObjects").sub("Airplanes");
 
 	Directory::ListT folders;
@@ -210,7 +210,7 @@ void TrafficMessageHandler::availableAircraft(std::string& output)
 		json.array("aircraft");
 
 		std::list<std::string> aircraft;
-		listAircraft(aircraft);
+		listAircraft(pSim, aircraft);
 		for (auto it = aircraft.begin(); it != aircraft.end(); ++it) {
 			json.object();
 			json.add("title", *it);

--- a/P3DInstruments/P3DControl/TrafficMessageHandler.h
+++ b/P3DInstruments/P3DControl/TrafficMessageHandler.h
@@ -16,7 +16,7 @@ public:
 	virtual ~TrafficMessageHandler();
 
 	static bool launch(Simulator* pSim, const std::string& targetName, const std::string& targetTailNumber, double targetRange, double targetSpeed, double relativeBearing, double relativeTargetHeight);
-	static std::list<std::string>& listAircraft(std::list<std::string>& aircraft);
+	static std::list<std::string>& listAircraft(Simulator* pSim, std::list<std::string>& aircraft);
 
 	virtual void run(const std::string& cmd, const APIParameters& params, std::string& output);
 

--- a/P3DInstruments/P3DControl/TrafficScripting.cpp
+++ b/P3DInstruments/P3DControl/TrafficScripting.cpp
@@ -33,8 +33,8 @@ int TrafficScripting::aircraft(lua_State* L)
 	int idx = 1;
 
 	try {
-
-		TrafficMessageHandler::listAircraft(aircraft);
+		Simulator* pSim = *(Simulator**)lua_getextraspace(L);
+		TrafficMessageHandler::listAircraft(pSim, aircraft);
 		for (auto it = aircraft.begin(); it != aircraft.end(); ++it) {
 			lua_pushstring(L, it->c_str());
 			lua_seti(L, -2, idx++);

--- a/P3DInstruments/P3DControl/WeatherMessageHandler.cpp
+++ b/P3DInstruments/P3DControl/WeatherMessageHandler.cpp
@@ -130,9 +130,9 @@ void WeatherMessageHandler::processTheme(File& file, std::string& name, std::str
 
 }
 
-File::ListT& WeatherMessageHandler::listThemes(File::ListT& fileList)
+File::ListT& WeatherMessageHandler::listThemes(Simulator* pSim, File::ListT& fileList)
 {
-	P3DInstallationDirectory p3dInstall;
+	P3DInstallationDirectory p3dInstall(pSim);
 	Directory themesFolder = p3dInstall.sub("Weather").sub("themes");
 
 	themesFolder.files(fileList, "*.wt");
@@ -508,7 +508,7 @@ void WeatherMessageHandler::listWeatherThemes(std::string& output)
 {
 	try {
 		File::ListT files;
-		listThemes(files);
+		listThemes(pSim, files);
 
 		JSONWriter json(output);
 		json.add("status", "OK");

--- a/P3DInstruments/P3DControl/WeatherMessageHandler.h
+++ b/P3DInstruments/P3DControl/WeatherMessageHandler.h
@@ -29,7 +29,7 @@ public:
 	static bool setCustom(Simulator* pSim);
 	static bool setTheme(Simulator* pSim, const std::string& themeName);
 	static void processTheme(File& file, std::string& name, std::string& title, std::string& description);
-	static File::ListT& listThemes(File::ListT& fileList);
+	static File::ListT& listThemes(Simulator* pSim, File::ListT& fileList);
 	static bool refresh(Simulator* pSim);
 	static std::string requestMetar(Simulator* pSim, const std::string& icao, std::string& name);
 	static std::string requestGlobalMetar(Simulator* pSim);

--- a/P3DInstruments/P3DControl/WeatherScripting.cpp
+++ b/P3DInstruments/P3DControl/WeatherScripting.cpp
@@ -56,7 +56,7 @@ int WeatherScripting::themes(lua_State* L)
 	try {
 		std::string filter(luaL_checkstring(L, 1));
 		File::ListT files;
-		WeatherMessageHandler::listThemes(files);
+		WeatherMessageHandler::listThemes(pSim, files);
 
 		lua_newtable(L);
 		int idx = 1;


### PR DESCRIPTION
- now uses version of p3d returned…from simconnect.  Prepa3d class now stores major/minor version numbers on startup.   Code uses these to select vX folder (where x is the version).  Should be fine for V6 etc.