### PR TITLE
default folder now v5 and log path overridable

### DIFF
--- a/P3DInstruments/P3DCommon/Prepar3D.cpp
+++ b/P3DInstruments/P3DCommon/Prepar3D.cpp
@@ -67,7 +67,7 @@ Prepar3D::Prepar3D(const char* appName, bool verbose)
 	wxStations(this),
 	extSim(0),
 	userAc(this),
-	majorVersion(4), // until proven otherwise
+	majorVersion(5), // until proven otherwise
 	minorVersion(0)
 {
 

--- a/P3DInstruments/P3DCommon/Prepar3D.h
+++ b/P3DInstruments/P3DCommon/Prepar3D.h
@@ -66,7 +66,7 @@ private:
 	SimObject userAc;
 	int majorVersion;
 	int minorVersion;
-	std::string documents = "Prepar3D v4 Files"; // fallback to v4
+	std::string documents = "Prepar3D v5 Files"; // fallback to v5
 
     static void CALLBACK DispatchCallback(SIMCONNECT_RECV *pData, DWORD cbData, void *pContext);
     void Process(SIMCONNECT_RECV *pData, DWORD cbData);

--- a/P3DInstruments/P3DControl/Logger.cpp
+++ b/P3DInstruments/P3DControl/Logger.cpp
@@ -11,7 +11,10 @@
 std::string Logger::getOutputPath(Prepar3D* p3d)
 {
 	DocumentDirectory documents;
-	Directory logFolder = documents.sub(p3d->documentsFolder()).sub("log");
+	
+	Directory logFolder = (logPath.empty())
+		? documents.sub(p3d->documentsFolder()).sub("log")
+		: Directory(logPath);
 
 	time_t now;
 	time(&now);
@@ -77,9 +80,31 @@ void Logger::write(Prepar3D* p3d, const std::string& text)
 	output->flush();
 }
 
-Logger::Logger()
+Logger::Logger(const char* logPath)
 	: output(0)
 {
+	if (logPath != nullptr) {
+		this->logPath = std::string(logPath);
+	}
+
+	if (this->logPath.empty()) {
+		// Check for the P3D_LOG environment variable.  If it exists and its a folder then use
+		// that instead.
+		char buffer[512];
+		auto size = ::GetEnvironmentVariableA("P3D_LOG", buffer, 512);
+		if (size > 0) {
+			auto dir = std::string(buffer, size);
+			DWORD dwAttrib = GetFileAttributesA(dir.c_str());
+
+			bool isDir = (dwAttrib != INVALID_FILE_ATTRIBUTES && (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+			if (isDir) {
+				this->logPath = dir;
+			}
+
+		}
+
+	}
+
 }
 
 Logger::~Logger()

--- a/P3DInstruments/P3DControl/Logger.h
+++ b/P3DInstruments/P3DControl/Logger.h
@@ -6,6 +6,7 @@ class Prepar3D;
 
 class Logger
 {
+	std::string logPath;
 	std::ofstream* output;
 
 	std::string getOutputPath(Prepar3D* p3d);
@@ -13,7 +14,7 @@ class Logger
 	void write(Prepar3D* p3d, const std::string& text);
 
 public:
-	Logger();
+	Logger(const char* logPath = nullptr);
 	~Logger();
 
 	void logCommand(Prepar3D* p3d,const std::string& cmd, const std::string& params);

--- a/P3DInstruments/P3DControl/P3DControl.cpp
+++ b/P3DInstruments/P3DControl/P3DControl.cpp
@@ -24,6 +24,7 @@ int main(int argc, char* argv[])
 	bool verbose = false;
 	unsigned short port = 3000;
 	std::string script;
+	std::string logpath;
 
 	for (int i = 1; i<argc; ) {
 		std::string arg = argv[i++];
@@ -44,6 +45,16 @@ int main(int argc, char* argv[])
 			}
 		}
 
+		else if (arg == "-log") {
+			if (i < argc) {
+				logpath = argv[i++];
+			}
+			else {
+				std::cerr << "Missing path parameter for -log option, ignoring this" << std::endl;
+			}
+		}
+
+
 		else if (arg == "-verbose") {
 			verbose = true;
 		}
@@ -62,7 +73,7 @@ int main(int argc, char* argv[])
 	HTTPService httpService;
 
 
-	Simulator sim("P3DControl",verbose);
+	Simulator sim("P3DControl",logpath.c_str(), verbose);
 
 	CommandInterpreter interpreter(&sim);
 

--- a/P3DInstruments/P3DControl/P3DControl.vcxproj.user
+++ b/P3DInstruments/P3DControl/P3DControl.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-verbose</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-verbose -log E:\TEMP</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/P3DInstruments/P3DControl/Simulator.cpp
+++ b/P3DInstruments/P3DControl/Simulator.cpp
@@ -10,7 +10,7 @@
 
 #include "../P3DCommon/SimObjectDataRequest.h"
 
-Simulator::Simulator(const char* appName, bool verbose)
+Simulator::Simulator(const char* appName, const char* logPath, bool verbose)
 	:Prepar3D(appName, verbose)
 	, state(0)
 	, stateRequest(0)
@@ -21,7 +21,7 @@ Simulator::Simulator(const char* appName, bool verbose)
 	, fr(0)
 	, pTug(0)
 {
-	logger = new Logger();
+	logger = new Logger(logPath);
 	logger->info(this,"Startup");
 	state = new SimState(this);
 	stateRequest = new SimObjectDataRequest(this, state, &userAircraft(), SIMCONNECT_PERIOD_SECOND);

--- a/P3DInstruments/P3DControl/Simulator.h
+++ b/P3DInstruments/P3DControl/Simulator.h
@@ -23,7 +23,7 @@ class Simulator : public Prepar3D
 
 
 public:
-	Simulator(const char* appName, bool verbose = false);
+	Simulator(const char* appName, const char* logPath, bool verbose = false);
 	~Simulator();
 
 	SimState* getState() { return state; }


### PR DESCRIPTION
Log path was defaulting to the P3d V4 (/log) folder in documents.  Default is now V5 but can be over-ridden by 
Command line: -log  c:\some_log_path
Environment variable: setx P3D_LOG c:\some_log_path